### PR TITLE
Fix xroad fetch and remove env logs

### DIFF
--- a/components/providers/supabase-provider.tsx
+++ b/components/providers/supabase-provider.tsx
@@ -7,11 +7,6 @@ import { createBrowserClient } from '@supabase/ssr' // 新しいインポート
 import type { SupabaseClient } from '@supabase/supabase-js' // SupabaseClientは@supabase/supabase-jsから取得
 import type { Database } from '@/lib/database.types'
 
-// ↓↓↓ ここに追加 ↓↓↓
-console.log('⛳️ URL =', process.env.NEXT_PUBLIC_SUPABASE_URL)
-console.log('⛳️ KEY =', process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY)
-// ↑↑↑ ここに追加 ↑↑↑
-
 type SupabaseContext = {
   supabase: SupabaseClient<Database>
 }


### PR DESCRIPTION
## Summary
- fix fetchFromXRoad to work in server environment
- remove debug logs exposing Supabase credentials

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'node')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ebc214f8832e9da42c587762a829